### PR TITLE
Improve translation

### DIFF
--- a/NPCMapLocations/i18n/es.json
+++ b/NPCMapLocations/i18n/es.json
@@ -1,15 +1,15 @@
 {
 	"immersion.label": "Ajustes:",
-	"immersion.option1": "Siempre Mostrar Aldeanos",
-	"immersion.option2": "Mostrar Aldeanos Con Los Que Se Ha Hablado",
-	"immersion.option3": "Esconder Aldeanos Con Los Que Se Ha Hablado",
-	"immersion.option4": "Solo Mostrar Aldeanos en La Ubicación Del Jugador",
-	"immersion.option5": "Solo Mostrar Aldeanos Dentro De Nivel De Corazones",
-	"immersion.slider1": "Nivel Mínimo de Corazones",
-	"immersion.slider2": "Nivel Máximo de Corazones",
-	"extra.label": "Ajustes Adicionales:",
-	"extra.option1": "Mostrar Misiones o Cumpleaños",
-	"extra.option2": "Mostrar Aldeanos Ocultos",
-	"extra.option3": "Mostrar Al Comerciante Ambulante",
-	"villagers.label": "Incluir/Excluir Aldeanos:"
+	"immersion.option1": "Mostrar aldeanos siempre",
+	"immersion.option2": "Mostrar aldeanos con los que ya has hablado",
+	"immersion.option3": "Ocultar aldeanos con los que ya has hablado",
+	"immersion.option4": "Mostrar solo los aldeanos en la misma ubicación que tú",
+	"immersion.option5": "Mostrar solo los aldeanos con cierto nivel de corazones",
+	"immersion.slider1": "Nivel mínimo de corazones",
+	"immersion.slider2": "Nivel máximo de corazones",
+	"extra.label": "Ajustes adicionales:",
+	"extra.option1": "Mostrar misiones o cumpleaños",
+	"extra.option2": "Mostrar aldeanos ocultos",
+	"extra.option3": "Mostrar al comerciante ambulante",
+	"villagers.label": "Incluir/excluir aldeanos:"
 }


### PR DESCRIPTION
Correct capital letters that are not used in Spanish. Improve translations so that they are better understood.