### PR TITLE
Fix compatibility issue with Quest Framework behavior

### DIFF
--- a/NPCMapLocations/ModMain.cs
+++ b/NPCMapLocations/ModMain.cs
@@ -816,19 +816,19 @@ namespace NPCMapLocations
         foreach (var quest in Game1.player.questLog)
         {
           if (quest.accepted.Value && quest.dailyQuest.Value && !quest.completed.Value)
-            switch (quest.questType.Value)
+            switch (quest)
             {
-              case 3:
-                npcMarker.HasQuest = ((ItemDeliveryQuest)quest).target.Value == npc.Name;
+              case ItemDeliveryQuest itemDeliveryQuest:
+                npcMarker.HasQuest = itemDeliveryQuest.target.Value == npc.Name;
                 break;
-              case 4:
-                npcMarker.HasQuest = ((SlayMonsterQuest)quest).target.Value == npc.Name;
+              case SlayMonsterQuest slayMonsterQuest:
+                npcMarker.HasQuest = slayMonsterQuest.target.Value == npc.Name;
                 break;
-              case 7:
-                npcMarker.HasQuest = ((FishingQuest)quest).target.Value == npc.Name;
+              case FishingQuest fishingQuest:
+                npcMarker.HasQuest = fishingQuest.target.Value == npc.Name;
                 break;
-              case 10:
-                npcMarker.HasQuest = ((ResourceCollectionQuest)quest).target.Value == npc.Name;
+              case ResourceCollectionQuest resourceCollectionQuest:
+                npcMarker.HasQuest = resourceCollectionQuest.target.Value == npc.Name;
                 break;
             }
         }
@@ -897,19 +897,19 @@ namespace NPCMapLocations
         // Check for daily quests
         foreach (var quest in Game1.player.questLog) { 
           if (quest.accepted.Value && quest.dailyQuest.Value && !quest.completed.Value)
-            switch (quest.questType.Value)
+            switch (quest)
             {
-              case 3:
-                marker.HasQuest = ((ItemDeliveryQuest)quest).target.Value == name;
+              case ItemDeliveryQuest itemDeliveryQuest:
+                marker.HasQuest = itemDeliveryQuest.target.Value == name;
                 break;
-              case 4:
-                marker.HasQuest = ((SlayMonsterQuest)quest).target.Value == name;
+              case SlayMonsterQuest slayMonsterQuest:
+                marker.HasQuest = slayMonsterQuest.target.Value == name;
                 break;
-              case 7:
-                marker.HasQuest = ((FishingQuest)quest).target.Value == name;
+              case FishingQuest fishingQuest:
+                marker.HasQuest = fishingQuest.target.Value == name;
                 break;
-              case 10:
-                marker.HasQuest = ((ResourceCollectionQuest)quest).target.Value == name;
+              case ResourceCollectionQuest resourceCollectionQuest:
+                marker.HasQuest = resourceCollectionQuest.target.Value == name;
                 break;
             }
         }


### PR DESCRIPTION
LenneDalben on the SDV Discord is working on a Quest Framework content pack. They encountered this error after getting their modded quest, causing NPC icons to disappear: [https://smapi.io/log/2dbbff40e66d475ab1e1ba141b326efa](https://smapi.io/log/2dbbff40e66d475ab1e1ba141b326efa)

This seems to be an issue with how Quest Framework uses the `Quest.questType` property; the values don't line up the subclasses expected by the `UpdateNpcs` and `UpdateNpcsFarmhand` methods. (This could probably be fixed in QF, but the author is currently on hiatus and bypassing it here seemed relatively simple.)

This PR directly compares `Quest` subclasses, which should avoid mismatch errors but otherwise work the same way.

I'm pretty new to PRs, so please let me know if there are any issues!