### PR TITLE
Beach farm fixes

### DIFF
--- a/NPCMapLocations/ModMain.cs
+++ b/NPCMapLocations/ModMain.cs
@@ -1087,7 +1087,7 @@ namespace NPCMapLocations
       if (locationName == "Farm")
       {
         // Handle different farm types for custom vectors
-        var farms = new string[6] { "Farm_Default", "Farm_Riverland", "Farm_Forest", "Farm_Hills", "Farm_Wilderness", "Farm_FourCorners" };
+        var farms = new string[7] { "Farm_Default", "Farm_Riverland", "Farm_Forest", "Farm_Hills", "Farm_Wilderness", "Farm_FourCorners", "Farm_Beach" };
         if (CustomMapVectors != null && (CustomMapVectors.Keys.Any(locName => locName == farms.ElementAtOrDefault(Game1.whichFarm))))
         {
           if (!CustomMapVectors.TryGetValue(farms.ElementAtOrDefault(Game1.whichFarm), out locVectors))
@@ -1099,8 +1099,13 @@ namespace NPCMapLocations
         {
           if (!CustomMapVectors.TryGetValue("Farm", out locVectors))
           {
-            locationNotFound = !ModConstants.MapVectors.TryGetValue(locationName, out locVectors);
+            locationNotFound = !ModConstants.MapVectors.TryGetValue(farms.ElementAtOrDefault(Game1.whichFarm), out locVectors);
+            if(locationNotFound)
+            {
+              locationNotFound = !ModConstants.MapVectors.TryGetValue(locationName, out locVectors);
+            }
           }
+
         }
       }
       // If not in custom vectors, use default

--- a/NPCMapLocations/data/ModConstants.cs
+++ b/NPCMapLocations/data/ModConstants.cs
@@ -109,6 +109,13 @@ public static class ModConstants
           }
       },
       {
+          "Farm_Beach", new MapVector[]
+          {
+              new MapVector(330, 237, 0, 0),
+              new MapVector(514, 386, 102, 106)
+          }
+      },
+      {
           "Farm_Region", new MapVector[]
           {
               new MapVector(423, 321)

--- a/NPCMapLocations/ui/ModMinimap.cs
+++ b/NPCMapLocations/ui/ModMinimap.cs
@@ -320,7 +320,7 @@ namespace NPCMapLocations
             Vector2.Zero, 4f, SpriteEffects.None, 0.861f);
           break;
         case 6:
-          b.Draw(ModMain.Map, new Vector2(farmX, farmY + 172),
+          b.Draw(ModMain.Map, new Vector2(farmX, farmY),
             new Rectangle(131 + farmCropX, 302 + farmCropY, farmCropWidth, farmCropHeight), color,
             0f,
             Vector2.Zero, 4f, SpriteEffects.None, 0.861f);


### PR DESCRIPTION
1. Fixing an accidentally added offset for the beach farms minimap texture which cause it to be drawn outside of the minimap window
2. Adding new map vectors specifically for the beach farm as it has a different shape and size to the other maps. (Might need to review the map sizes, I used the debug feature to get it roughly correct)