### PR TITLE
Fix missing label in NPC Map Locations settings

### DIFF
--- a/NPCMapLocations/Framework/Menus/ModMenu.cs
+++ b/NPCMapLocations/Framework/Menus/ModMenu.cs
@@ -120,6 +120,8 @@ namespace NPCMapLocations.Framework.Menus
             this.Options.Add(new MapModSlider("immersion.slider1", 8, -1, -1, 0, 12));
             this.Options.Add(new MapModSlider("immersion.slider2", 9, -1, -1, 0, 12));
 
+            string extraLabel = ModEntry.StaticHelper.Translation.Get("extra.label");
+            this.Options.Add(new OptionsElement(extraLabel));
             this.Options.Add(new ModCheckbox("extra.option1", 10, -1, -1));
             this.Options.Add(new ModCheckbox("extra.option2", 11, -1, -1));
             this.Options.Add(new ModCheckbox("extra.option3", 12, -1, -1));


### PR DESCRIPTION
localization files contain "extra.label" string which isn't seen in the mod settings