### PR TITLE
Add npc.IsInvisible check to exclude from showing on world map

### DIFF
--- a/NPCMapLocations/ModEntry.cs
+++ b/NPCMapLocations/ModEntry.cs
@@ -592,7 +592,7 @@ namespace NPCMapLocations
             {
                 bool shouldTrack =
                     npc != null
-                    && npc.IsInvisible != true
+                    && !npc.IsInvisible
                     && !ModConstants.ExcludedNpcs.Contains(npc.Name) // note: don't check Globals.NPCExclusions here, so player can still reenable them in the map options UI
                     && (
                         npc.isVillager()

--- a/NPCMapLocations/ModEntry.cs
+++ b/NPCMapLocations/ModEntry.cs
@@ -592,6 +592,7 @@ namespace NPCMapLocations
             {
                 bool shouldTrack =
                     npc != null
+                    && npc.IsInvisible != true
                     && !ModConstants.ExcludedNpcs.Contains(npc.Name) // note: don't check Globals.NPCExclusions here, so player can still reenable them in the map options UI
                     && (
                         npc.isVillager()


### PR DESCRIPTION
**Change**
Added `&& npc.IsInvisible != true` inside code that creates a list of eligible villagers for map markers.

**Purpose**
If an NPC is invisible, this change will prevent them from being eligible for being on the list of villagers to display on the world map. Once they are visible, they will be added to the list and can be displayed on the world map.

**Testing**
Has been tested and confirmed to work with world map and mini-map, in single player and multiplayer. Works with vanilla and custom NPCs. Changes to NPC visibility on the map don't happen until next day if NPC is made invisible partway through a day. Removes NPC from the config list while invisible and re-adds them once they are visible again. Choosing "show hidden villagers" in the options does not show them on the map while they are invisible.