### PR TITLE
[NPC Map Locations] Prevent NPC icons from being stretched or squashed due to very non-square source rectangles.

### DIFF
--- a/NPCMapLocations/Framework/Menus/ModMapPage.cs
+++ b/NPCMapLocations/Framework/Menus/ModMapPage.cs
@@ -319,10 +319,16 @@ internal class ModMapPage : MapPage
                 var markerColor = (marker.IsHidden ? Color.DarkGray * 0.7f : Color.White) * alpha;
 
                 // Draw NPC marker
-                Rectangle spriteRect = marker.GetSpriteSourceRect();
-                float multiplier = spriteRect.Width > spriteRect.Height ? 32f / spriteRect.Width : 30f / spriteRect.Height;
-                b.Draw(marker.Sprite, new Rectangle(this.mapBounds.X + marker.WorldMapPosition.X, this.mapBounds.Y + marker.WorldMapPosition.Y,
-                    (int)(spriteRect.Width * multiplier), (int)(spriteRect.Height * multiplier)), spriteRect, markerColor);
+                {
+                    Rectangle spriteRect = marker.GetSpriteSourceRect();
+                    float iconScale = spriteRect.Width > spriteRect.Height
+                        ? 32f / spriteRect.Width
+                        : 30f / spriteRect.Height;
+
+                    Rectangle destinationRect = new Rectangle(this.mapBounds.X + marker.WorldMapPosition.X, this.mapBounds.Y + marker.WorldMapPosition.Y, (int)(spriteRect.Width * iconScale), (int)(spriteRect.Height * iconScale));
+
+                    b.Draw(marker.Sprite, destinationRect, spriteRect, markerColor);
+                }
 
                 // Draw icons for quests/birthday
                 if (ModEntry.Globals.ShowQuests)

--- a/NPCMapLocations/Framework/Menus/ModMapPage.cs
+++ b/NPCMapLocations/Framework/Menus/ModMapPage.cs
@@ -320,7 +320,9 @@ internal class ModMapPage : MapPage
 
                 // Draw NPC marker
                 Rectangle spriteRect = marker.GetSpriteSourceRect();
-                b.Draw(marker.Sprite, new Rectangle(this.mapBounds.X + marker.WorldMapPosition.X, this.mapBounds.Y + marker.WorldMapPosition.Y, 32, 30), spriteRect, markerColor);
+                float multiplier = spriteRect.Width > spriteRect.Height ? 32f / spriteRect.Width : 30f / spriteRect.Height;
+                b.Draw(marker.Sprite, new Rectangle(this.mapBounds.X + marker.WorldMapPosition.X, this.mapBounds.Y + marker.WorldMapPosition.Y,
+                    (int)(spriteRect.Width * multiplier), (int)(spriteRect.Height * multiplier)), spriteRect, markerColor);
 
                 // Draw icons for quests/birthday
                 if (ModEntry.Globals.ShowQuests)

--- a/NPCMapLocations/ModEntry.cs
+++ b/NPCMapLocations/ModEntry.cs
@@ -611,8 +611,8 @@ public class ModEntry : Mod
         return villagers;
     }
 
-    // For drawing farm buildings on the map 
-    // and getting positions relative to the farm 
+    // For drawing farm buildings on the map
+    // and getting positions relative to the farm
     private void UpdateFarmBuildingLocations()
     {
         FarmBuildings.Clear();
@@ -742,7 +742,7 @@ public class ModEntry : Mod
                     LocationName = "Town",
                     CropOffset = 0,
                     Sprite = Game1.mouseCursors_1_6,
-                    SpriteSourceRect = new Rectangle(181, 490, 12, 18),
+                    SpriteSourceRect = new Rectangle(180, 490, 14, 18),
                     SpriteZoom = 1.5f,
                     WorldMapPosition = mapPos
                 });


### PR DESCRIPTION
This PR alters the draw code for NPC markers so that instead of hardcoding the destination rectangle to be drawn to 32x30, which works fine for NPCs (and mostly fine for the horse), it instead multiplies the marker's source rect by whatever factor will take its _largest_ axis to 32 or 30, depending on whether the largest axis is width or height respectively. The previous draw code resulted in a very squashed Bookseller icon, since his 12x18 sourceRect was put inside a 32x30 rectangle and stretched to fit it completely. Now, his icon will remain 30 pixels tall and 20 pixels wide, looking much better, if relatively smaller compared to some other NPC faces, but likely preferred to the stretched version. Naturally, this will extend to any other NPCs with non-square rects (like the horse) to make them nice again.

This PR also slightly alters the hardcoded source rect for the Bookseller's NpcMarker to fit the new draw code better.

Both of these changes are, of course, subjective, so no hard feelings if any or all of the PR is discarded outright.

![StardewModdingAPI-2025-04-11-01-05-10685 2](https://github.com/user-attachments/assets/6b741a56-b3e0-43b5-830f-7a80748223a9)