### PR TITLE
Fix tooltip key for ShowFarmBuildings config setting

### DIFF
--- a/NPCMapLocations/Framework/GenericModConfigMenuIntegration.cs
+++ b/NPCMapLocations/Framework/GenericModConfigMenuIntegration.cs
@@ -171,7 +171,7 @@ internal class GenericModConfigMenuIntegration
         menu.AddBoolOption(
             this.Manifest,
             name: I18n.Config_ShowFarmBuildings_Name,
-            tooltip: I18n.Config_ShowFarmBuildings_Name,
+            tooltip: I18n.Config_ShowFarmBuildings_Desc,
             getValue: () => this.Config.ShowFarmBuildings,
             setValue: value => this.Config.ShowFarmBuildings = value
         );


### PR DESCRIPTION
The tooltip was using the name key instead of the description key, so I fixed it.

I found this while working on a Japanese translation.
I don't usually work with C#, so apologies if I missed anything.